### PR TITLE
External value change propagates to pickadate

### DIFF
--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -23,17 +23,26 @@ export default Ember.Component.extend({
   },
 
   updateDate: Ember.observer('value', function() {
-    var date = this.get('date');
+    var date = this.get('date'),
+        value = this.get('value'),
+        picker = this.get('picker'),
+        format = this.get('options.format') || 'd mmmm, yyyy';
+
+    if (value !== picker.get('select', format)) {
+      picker.set('select', value, { format: format } );
+      return;
+    }
 
     if (!date) {
       date = new Date();
       this.set('date', date);
     }
 
-    var dateItem = this.get('picker').get('select');
+    var dateItem = picker.get('select');
     if (!dateItem) {
       return;
     }
+
     date.setYear(dateItem.year);
     date.setMonth(dateItem.month);
     date.setDate(dateItem.date);

--- a/tests/integration/components/pick-a-date-test.js
+++ b/tests/integration/components/pick-a-date-test.js
@@ -53,3 +53,39 @@ test('date is updated', function(assert) {
     assert.ok(this.get('date').getMinutes() === initialDate.getMinutes(), "Minutes didn't change");
   });
 });
+
+test('date picker is updated on value change', function(assert) {
+  const DAY_IN_MILLISECONDS = 86400000;
+  let date = new Date();
+  let options = { format: "mm/dd/yyyy" };
+  let padNumber = function(number) { return number < 10 ? '0' + number : String(number); };
+  let formattedDate = padNumber(date.getMonth() + 1) + '/' + padNumber(date.getDate()) + '/' + date.getFullYear();
+  let $input;
+
+  this.set('options', options);
+  this.set('value', undefined);
+  this.set('date', undefined);
+
+  this.render(hbs`
+    {{pick-a-date
+      date=date
+      value=value
+      options=options
+    }}
+  `);
+
+  $input = this.$('.ember-pick-a-date input');
+  assert.equal($input.val(), "", "Expected input value to be empty");
+
+  this.set('date', new Date(date.getTime() + DAY_IN_MILLISECONDS));
+  this.set('value', formattedDate);
+
+  Ember.run.next(() => {
+    assert.equal($input.val(), formattedDate, "Expected input value to be set to date");
+    assert.equal($input.pickadate('picker').get('select', options.format), formattedDate, "Expected pick a date to have date selected");
+    //This ensures we don't get into weird cyclical conditions
+    //If the user wants to set the value of the pick a date from an external source
+    //then it is assumed they are setting it from the date object they passed into date=
+    assert.notEqual(this.get('date'), date, 'Does not set date when value is set');
+  });
+});


### PR DESCRIPTION
When the value that is bound to the input box changes because of a
reason that is not pick a date. Pick a date should update
