### PR TITLE
Let user specify theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ All parameters are optional.
 
 You can pass the same date object to both pickers.
 
+### Build Options
+You can specify options to the add-on using the "ember-cli-pickadate" config property in your ember-cli-build.js (or in Brocfile.js if you are using an Ember CLI version older than 1.13):
+
+```
+var app = new EmberApp({
+  "ember-cli-pickadate": { [options] }
+});
+```
+
+Options:
+
+* `theme`: specify a theme to use (default: 'default')
+
+
+
 ## License
 
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -4,13 +4,19 @@
 module.exports = {
   name: 'ember-cli-pickadate',
   included: function(app) {
+    var options = app.options[this.name] || {};
+
     this._super.included(app);
+
+    if (!options.theme) {
+      options.theme = 'default';
+    }
 
     app.import(app.bowerDirectory + '/pickadate/lib/picker.js');
     app.import(app.bowerDirectory + '/pickadate/lib/picker.date.js');
     app.import(app.bowerDirectory + '/pickadate/lib/picker.time.js');
-    app.import(app.bowerDirectory + '/pickadate/lib/themes/default.css');
-    app.import(app.bowerDirectory + '/pickadate/lib/themes/default.date.css');
-    app.import(app.bowerDirectory + '/pickadate/lib/themes/default.time.css');
+    app.import(app.bowerDirectory + '/pickadate/lib/themes/' + options.theme + '.css');
+    app.import(app.bowerDirectory + '/pickadate/lib/themes/' + options.theme + '.date.css');
+    app.import(app.bowerDirectory + '/pickadate/lib/themes/' + options.theme + '.time.css');
   }
 };


### PR DESCRIPTION
A user can now specify a theme to use for pick-a-date. By default we use
the 'default' theme.
To override the theme you can pass it into the EmberApp instance in
your including application's ember-cli-build.js file

```
var app = new EmberApp({
  "ember-cli-pickadate": { theme: 'classic' }
});
```
