### PR TITLE
Updated for Ember 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+# webstorm
+.idea/

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ For more information on using ember-cli, visit [http://www.ember-cli.com/](http:
 ## Usage
 
 ### Date Picker
+* Note that if using they curly HTMLBars syntax you need pass all attributes as `attribute=(readonly VALUE)`, this is the default for angle bracket components.
 ```html
-{{pick-a-date date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a date" options=extraPickadateOptions}}
+{{pick-a-date date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a date" options=(readonly extraPickadateOptions)}}
 ```
 
 or the following syntax if you have angle bracket components.
@@ -37,8 +38,10 @@ or the following syntax if you have angle bracket components.
  * on-selected - (function) Called when a date is selected and passed the new date as the first argument.
 
 ### Time Picker
+
+* Note that if using they curly HTMLBars syntax you need pass all attributes as `attribute=(readonly VALUE)`, this is the default for angle bracket components.
 ```html
-{{pick-a-time date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a time" options=extraPickadateOptions}}
+{{pick-a-time date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a time" options=(readonly extraPickadateOptions)}}
 ```
 
 or the following syntax if you have angle bracket components.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,34 @@ For more information on using ember-cli, visit [http://www.ember-cli.com/](http:
 ## Usage
 
 ### Date Picker
-`{{pick-a-date date=date placeholder="Pick a date" options=extraPickadateOptions}}`
+`{{pick-a-date date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a date" options=extraPickadateOptions}}`
+
+or the following syntax if you have angle bracket components.
+
+`<pick-a-date date={{date}} on-selected=(action (mut date)) placeholder="Pick a date" options={{extraPickadateOptions}}>`
+
+#### Parameters
+ * disabled - (string) Disable the datepicker
+ * placeholder - (string) The text to display in the input when nothing is selected
+ * options - (object) Options available via the pick-a-date API
+ * date - (Date) The date to display
+ * on-selected - (function) Called when a date is selected and passed the new date as the first argument.
 
 ### Time Picker
-`{{pick-a-time date=date placeholder="Pick a time" options=extraPickadateOptions}}`
+`{{pick-a-time date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a time" options=extraPickadateOptions}}`
+
+or the following syntax if you have angle bracket components.
+
+`<pick-a-time date={{date}} on-selected=(action (mut date)) placeholder="Pick a time" options={{extraPickadateOptions}}>`
+
+#### Parameters
+ * disabled - (string) Disable the timepicker
+ * placeholder - (string) The text to display in the input when nothing is selected
+ * options - (object) Options available via the pick-a-date API
+ * date - (Date) The date to display (of which the time part will be displayed to the user)
+ * on-selected - (function) Called when a date is selected and passed the new date as the first argument.
+ * nulls-date - (boolean) If true, will set the date to null when the clear button is pressed.
+                          If false, will set the time part to 0 only when the clear button is pressed, the date part is unaffected.
 
 All parameters are optional.
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ For more information on using ember-cli, visit [http://www.ember-cli.com/](http:
 ## Usage
 
 ### Date Picker
-`{{pick-a-date date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a date" options=extraPickadateOptions}}`
+```html
+{{pick-a-date date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a date" options=extraPickadateOptions}}
+```
 
 or the following syntax if you have angle bracket components.
-
-`<pick-a-date date={{date}} on-selected=(action (mut date)) placeholder="Pick a date" options={{extraPickadateOptions}}>`
+```html
+<pick-a-date date={{date}} on-selected=(action (mut date)) placeholder="Pick a date" options={{extraPickadateOptions}}>
+```
 
 #### Parameters
  * disabled - (string) Disable the datepicker
@@ -34,11 +37,14 @@ or the following syntax if you have angle bracket components.
  * on-selected - (function) Called when a date is selected and passed the new date as the first argument.
 
 ### Time Picker
-`{{pick-a-time date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a time" options=extraPickadateOptions}}`
+```html
+{{pick-a-time date=(readonly date) on-selected=(action (mut date)) placeholder="Pick a time" options=extraPickadateOptions}}
+```
 
 or the following syntax if you have angle bracket components.
-
-`<pick-a-time date={{date}} on-selected=(action (mut date)) placeholder="Pick a time" options={{extraPickadateOptions}}>`
+```html
+<pick-a-time date={{date}} on-selected=(action (mut date)) placeholder="Pick a time" options={{extraPickadateOptions}}>
+```
 
 #### Parameters
  * disabled - (string) Disable the timepicker
@@ -48,6 +54,8 @@ or the following syntax if you have angle bracket components.
  * on-selected - (function) Called when a date is selected and passed the new date as the first argument.
  * nulls-date - (boolean) If true, will set the date to null when the clear button is pressed.
                           If false, will set the time part to 0 only when the clear button is pressed, the date part is unaffected.
+
+----------------------
 
 All parameters are optional.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or the following syntax if you have angle bracket components.
 ```
 
 #### Parameters
- * disabled - (string) Disable the datepicker
+ * disabled - (boolean) Disable the datepicker
  * placeholder - (string) The text to display in the input when nothing is selected
  * options - (object) Options available via the pick-a-date API
  * date - (Date) The date to display
@@ -47,7 +47,7 @@ or the following syntax if you have angle bracket components.
 ```
 
 #### Parameters
- * disabled - (string) Disable the timepicker
+ * disabled - (boolean) Disable the timepicker
  * placeholder - (string) The text to display in the input when nothing is selected
  * options - (object) Options available via the pick-a-date API
  * date - (Date) The date to display (of which the time part will be displayed to the user)

--- a/addon/components/common.js
+++ b/addon/components/common.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+
+});

--- a/addon/components/common.js
+++ b/addon/components/common.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-const { Component } = Ember;
-
-export default Component.extend({
-
-});

--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -6,7 +6,7 @@ const DEFAULT_DATE_FORMAT = 'd mmmm, yyyy';
 /**
  * @public
  *
- * @param disabled - (string) disable the datepicker
+ * @param disabled - (boolean) disable the datepicker
  * @param placeholder - (string) the text to display in the input when nothing is selected
  * @param options - (object) options available via the pick-a-date API (http://amsul.ca/pickadate.js/)
  * @param date - (Date) the date to display

--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -42,10 +42,13 @@ export default Component.extend({
     const options = this.attrs.options || {};
     const format = options.format || DEFAULT_DATE_FORMAT;
     const picker = this.get('picker');
-    picker.set('select', date, {
-      format: format,
-      muted: true
-    });
+
+    if (!picker.get('open')) {
+      picker.set('select', date, {
+        format: format,
+        muted: true
+      });
+    }
   },
 
   toggleInputDisabled: function() {

--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -1,52 +1,97 @@
 import Ember from 'ember';
-import layout from '../templates/components/pick-a-date';
 
-export default Ember.Component.extend({
-  layout: layout,
-  picker: null,
+const { Component } = Ember;
+const DEFAULT_DATE_FORMAT = 'd mmmm, yyyy';
+
+/**
+ * @public
+ *
+ * @param disabled - (string) disable the datepicker
+ * @param placeholder - (string) the text to display in the input when nothing is selected
+ * @param options - (object) options available via the pick-a-date API (http://amsul.ca/pickadate.js/)
+ * @param date - (Date) the date to display
+ * @param on-selected - (function) called when a date is selected and passed the new date as the first argument.
+ */
+export default Component.extend({
+  tagName: 'input',
+  attributeBindings: ['placeholder', 'disabled', 'type'],
+  disabled: null,
+  type: 'text',
   placeholder: "Select a date",
-  options: {},
-  value: null,
+  picker: null,
   date: null,
   classNames: ['ember-pick-a-date'],
 
-  connectPickadate: Ember.on('didInsertElement', function() {
-    var options = this.get('options');
+  didInsertElement() {
+    const options = this.attrs.options || {};
     options.onClose = options.onClose || this.onClose;
-    this.$('input').pickadate(options);
-    this.set('picker', this.$('input').pickadate('picker'));
-  }),
+    options.onSet = () => {
+      this.onSelected();
+    };
+    this.$().pickadate(options);
+    this.set('picker', this.$().pickadate('picker'));
+  },
 
-  onClose: function(){
+  didRender() {
+    this.updateInputText();
+    this.toggleInputDisabled();
+  },
+
+  updateInputText() {
+    const date = this.get('date');
+    const options = this.attrs.options || {};
+    const format = options.format || DEFAULT_DATE_FORMAT;
+    const picker = this.get('picker');
+    picker.set('select', date, {
+      format: format,
+      muted: true
+    });
+  },
+
+  toggleInputDisabled: function() {
+    if(this.get('disabled')) {
+      this.get('picker').stop();
+      this.$().prop('disabled', true); // pick-a-date is doing funny things with the disabled attribute
+    } else {
+      this.get('picker').start();
+      this.$().prop('disabled', false);
+    }
+  },
+
+  onClose() {
     // Prevent pickadate from re-opening on focus
     Ember.$(document.activeElement).blur();
   },
 
-  updateDate: Ember.observer('value', function() {
-    var date = this.get('date'),
-        value = this.get('value'),
-        picker = this.get('picker'),
-        format = this.get('options.format') || 'd mmmm, yyyy';
-
-    if (value !== picker.get('select', format)) {
-      picker.set('select', value, { format: format } );
-      return;
-    }
-
-    if (!date) {
-      date = new Date();
-      this.set('date', date);
-    }
-
-    var dateItem = picker.get('select');
+  onSelected(){
+    const date = this.get('date') || new Date();
+    const picker = this.get('picker');
+    const dateItem = picker.get('select');
     if (!dateItem) {
+      if (this.attrs['on-selected']) {
+        this.attrs['on-selected'](null);
+      }
       return;
     }
 
-    let newDate = new Date(date);
+    const newDate = new Date(date);
     newDate.setYear(dateItem.year);
     newDate.setMonth(dateItem.month);
     newDate.setDate(dateItem.date);
-    this.set('date', newDate);
-  })
+    if (this.attrs['on-selected']) {
+      if (newDate && !isNaN(newDate.getTime())) { //Number.isNaN PhantomJs does not like this yet
+        this.attrs['on-selected'](newDate);
+      } else {
+        this.attrs['on-selected'](null);
+      }
+    }
+  },
+
+  willDestroyElement() {
+    const picker = this.get('picker');
+    if (picker && picker.get('start')) {
+      picker.stop();
+    }
+  }
+
 });

--- a/addon/components/pick-a-time.js
+++ b/addon/components/pick-a-time.js
@@ -43,10 +43,13 @@ export default Component.extend({
     const options = this.attrs.options || {};
     const format = options.format || DEFAULT_TIME_FORMAT;
     const picker = this.get('picker');
-    picker.set('select', date, {
-      format: format,
-      muted: true
-    });
+
+    if (!picker.get('open')) {
+      picker.set('select', date, {
+        format: format,
+        muted: true
+      });
+    }
   },
 
   toggleInputDisabled: function() {

--- a/addon/components/pick-a-time.js
+++ b/addon/components/pick-a-time.js
@@ -6,7 +6,7 @@ const DEFAULT_TIME_FORMAT = 'hh-i';
 /**
  * @public
  *
- * @param disabled - (string) Disable the timepicker
+ * @param disabled - (boolean) Disable the timepicker
  * @param placeholder - (string) The text to display in the input when nothing is selected
  * @param options - (object) Options available via the pick-a-date API
  * @param date - (Date) The inital date to display

--- a/addon/components/pick-a-time.js
+++ b/addon/components/pick-a-time.js
@@ -69,7 +69,7 @@ export default Component.extend({
     const dateItem = this.get('picker').get('select');
     let newDate = new Date(date);
     if (isNone(dateItem)) {
-      if(this.attrs['nulls-date']) {
+      if(this.attrs['nulls-date'] === true) {
         newDate = null;
       } else {
         newDate.setHours(0, 0, 0, 0);

--- a/addon/components/pick-a-time.js
+++ b/addon/components/pick-a-time.js
@@ -1,42 +1,93 @@
 import Ember from 'ember';
-import layout from '../templates/components/pick-a-time';
 
-export default Ember.Component.extend({
-  layout: layout,
-  picker: null,
+const { isNone, Component } = Ember;
+const DEFAULT_TIME_FORMAT = 'hh-i';
+
+/**
+ * @public
+ *
+ * @param disabled - (string) Disable the timepicker
+ * @param placeholder - (string) The text to display in the input when nothing is selected
+ * @param options - (object) Options available via the pick-a-date API
+ * @param date - (Date) The inital date to display
+ * @param on-selected - (function) Called when a time is selected and passed the new date as the first argument.
+ * @param nulls-date - (boolean) If true, will set the date to null when the clear button is pressed.
+ *                               If false, will set the time part to 0 only when the clear button is pressed, the date part is unaffected.
+ */
+export default Component.extend({
+  tagName: 'input',
+  attributeBindings: ['placeholder', 'disabled', 'type'],
+  disabled: null,
+  type: 'text',
   placeholder: "Select a time",
-  options: {},
-  value: null,
-  date: null,
+  picker: null,
   classNames: ['ember-pick-a-time'],
 
-  connectPickatime: Ember.on('didInsertElement', function() {
-    var options = this.get('options');
+  didInsertElement() {
+    const options = this.attrs.options || {};
     options.onClose = options.onClose || this.onClose;
-    this.$('input').pickatime(options);
-    this.set('picker', this.$('input').pickatime('picker'));
-  }),
+    options.onSet = () => {
+      this.onSelected();
+    };
+    this.$().pickatime(options);
+    this.set('picker', this.$().pickatime('picker'));
+  },
 
-  onClose: function(){
+  didRender() {
+    this.updateInputText();
+    this.toggleInputDisabled();
+  },
+
+  updateInputText() {
+    const date = this.get('date');
+    const options = this.attrs.options || {};
+    const format = options.format || DEFAULT_TIME_FORMAT;
+    const picker = this.get('picker');
+    picker.set('select', date, {
+      format: format,
+      muted: true
+    });
+  },
+
+  toggleInputDisabled: function() {
+    if(this.get('disabled')) {
+      this.get('picker').stop();
+      this.$().prop('disabled', true); // pick-a-date is doing funny things with the disabled attribute
+    } else {
+      this.get('picker').start();
+      this.$().prop('disabled', false);
+    }
+  },
+
+  onClose(){
     // Prevent pickadate from re-opening on focus
     Ember.$(document.activeElement).blur();
   },
 
-  updateDate: Ember.observer('value', function() {
-    var date = this.get('date');
-
-    if (!date) {
-      date = new Date();
-      this.set('date', date);
-    }
-
-    var dateItem = this.get('picker').get('select');
-    if (!dateItem) {
-      return;
-    }
-
+  onSelected(){
+    const date = this.get('date') || new Date();
+    const dateItem = this.get('picker').get('select');
     let newDate = new Date(date);
-    newDate.setHours(dateItem.hour, dateItem.mins, 0, 0);
-    this.set('date', newDate);
-  })
+    if (isNone(dateItem)) {
+      if(this.attrs['nulls-date']) {
+        newDate = null;
+      } else {
+        newDate.setHours(0, 0, 0, 0);
+      }
+    } else {
+      newDate.setHours(dateItem.hour, dateItem.mins, 0, 0);
+    }
+
+    if (this.attrs['on-selected']) {
+      this.attrs['on-selected'](newDate);
+    }
+  },
+
+  willDestroyElement() {
+    const picker = this.get('picker');
+    if (picker && picker.get('start')) {
+      picker.stop();
+    }
+  }
+
 });

--- a/addon/styles/pick-a-date.css
+++ b/addon/styles/pick-a-date.css
@@ -1,0 +1,6 @@
+/* Bootstrap 3 Fix */
+.picker__input[readonly],
+.picker__input:hover {
+  background: #fff;
+  cursor: text;
+}

--- a/addon/templates/components/pick-a-date.hbs
+++ b/addon/templates/components/pick-a-date.hbs
@@ -1,1 +1,0 @@
-{{input type='text' value=value placeholder=placeholder}}

--- a/addon/templates/components/pick-a-time.hbs
+++ b/addon/templates/components/pick-a-time.hbs
@@ -1,1 +1,0 @@
-{{input type='text' value=value placeholder=placeholder}}

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-cli-pickadate",
   "dependencies": {
-    "ember": "1.13.6",
+    "ember": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.7",
+    "ember-data": "2.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",

--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,8 @@
   },
   "devDependencies": {
     "pickadate": "AddJam/pickadate.js#cd23958028a62035bd684b9368eca4444805563d"
+  },
+  "resolutions": {
+    "ember": "2.1.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   name: 'ember-cli-pickadate',
+  isDevelopingAddon: function() { return true; },
   included: function(app) {
     var options = app.options[this.name] || {};
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.1",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.7",
+    "ember-data": "2.1.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  date: null
+  date: null,
+  date2: new Date(),
+  dateDisabled: false,
+  datePlaceholder: 'Pick a date',
+  timeDisabled: false,
+  timePlaceholder: 'Pick a time',
+  nullsDate: false
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,17 @@
 <h1>Pickadate for Ember</h1>
 
 <h2>Date picker</h2>
-{{pick-a-date date=date}}
+{{input type="checkbox" checked=dateDisabled}} Disable?<br>
+Placeholder {{input value=datePlaceholder}}<br>
+<br>
+<h3>Empty Date</h3>
+{{pick-a-date date=date on-selected=(action (mut date)) disabled=dateDisabled placeholder=datePlaceholder}}
+<h3>Todays Date</h3>
+{{pick-a-date date=date2 on-selected=(action (mut date2)) disabled=dateDisabled placeholder=datePlaceholder}}
 
 <h2>Time picker</h2>
-{{pick-a-time date=date}}
+{{input type="checkbox" checked=timeDisabled}} Disable?<br>
+Placeholder {{input value=timePlaceholder}}<br>
+{{input type="checkbox" checked=nullsDate}} Clearing time nulls out date?<br>
+<br>
+{{pick-a-time date=date on-selected=(action (mut date)) nulls-date=(readonly nullsDate) disabled=timeDisabled placeholder=timePlaceholder}}

--- a/tests/integration/components/pick-a-date-test.js
+++ b/tests/integration/components/pick-a-date-test.js
@@ -36,7 +36,7 @@ test('date is updated', function(assert) {
   let date = new Date();
   let initialDate = new Date(date);
   this.set('date', date);
-  this.render(hbs`{{pick-a-date date=date on-selected=(action (mut date))}}`);
+  this.render(hbs`{{pick-a-date date=(readonly date) on-selected=(action (mut date))}}`);
 
   assert.ok(this.get('date') === date, "Date set");
 
@@ -66,7 +66,7 @@ test('date picker is updated on value change', function(assert) {
 
   this.render(hbs`
     {{pick-a-date
-      date=date
+      date=(readonly date)
       options=options
       on-selected=(action (mut date))
     }}
@@ -87,3 +87,22 @@ test('date picker is updated on value change', function(assert) {
     assert.notEqual(this.get('date'), date, 'Does not set date when value is set');
   });
 });
+
+test('can toggle disabled property', function(assert) {
+  this.set('disabled', true);
+  this.set('date', undefined);
+
+  this.render(hbs`
+    {{pick-a-date
+      date=(readonly date)
+      disabled=(readonly disabled)
+    }}
+  `);
+
+  let $input = this.$('input');
+  assert.equal($input.prop('disabled'), true);
+
+  this.set('disabled', false);
+  assert.equal($input.prop('disabled'), false);
+});
+

--- a/tests/integration/components/pick-a-date-test.js
+++ b/tests/integration/components/pick-a-date-test.js
@@ -7,24 +7,23 @@ moduleForComponent('pick-a-date', 'Integration | Component | pick a date', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
   this.render(hbs`{{pick-a-date}}`);
 
-  assert.equal(this.$('.ember-pick-a-date').length, 1);
-  assert.equal(this.$('.ember-pick-a-date input').length, 1);
+  assert.equal(this.$().length, 1);
 });
 
 test('placeholder is set', function(assert) {
   assert.expect(1);
   this.render(hbs`{{pick-a-date placeholder='pew'}}`);
 
-  assert.equal(this.$('.ember-pick-a-date input').attr('placeholder'), 'pew');
+  assert.equal(this.$('input').attr('placeholder'), 'pew');
 });
 
 test('clicking input opens picker', function(assert) {
   assert.expect(2);
   this.render(hbs`{{pick-a-date}}`);
-  let $input = this.$('.ember-pick-a-date input');
+  let $input = this.$('input');
 
   assert.notOk($input.hasClass('picker__input--active'));
 
@@ -37,14 +36,14 @@ test('date is updated', function(assert) {
   let date = new Date();
   let initialDate = new Date(date);
   this.set('date', date);
-  this.render(hbs`{{pick-a-date date=date}}`);
+  this.render(hbs`{{pick-a-date date=date on-selected=(action (mut date))}}`);
 
   assert.ok(this.get('date') === date, "Date set");
 
-  this.$('.ember-pick-a-date input').click();
+  this.$().click();
 
   Ember.run.next(() => {
-    this.$('.ember-pick-a-date .picker__day--infocus').click();
+    this.$('.picker__day--infocus').click();
 
     assert.ok(this.get('date') !== initialDate, "Date changed");
 
@@ -63,26 +62,25 @@ test('date picker is updated on value change', function(assert) {
   let $input;
 
   this.set('options', options);
-  this.set('value', undefined);
   this.set('date', undefined);
 
   this.render(hbs`
     {{pick-a-date
       date=date
-      value=value
       options=options
+      on-selected=(action (mut date))
     }}
   `);
 
-  $input = this.$('.ember-pick-a-date input');
+  $input = this.$('input');
   assert.equal($input.val(), "", "Expected input value to be empty");
 
   this.set('date', new Date(date.getTime() + DAY_IN_MILLISECONDS));
-  this.set('value', formattedDate);
+  $input.val(formattedDate);
 
   Ember.run.next(() => {
     assert.equal($input.val(), formattedDate, "Expected input value to be set to date");
-    assert.equal($input.pickadate('picker').get('select', options.format), formattedDate, "Expected pick a date to have date selected");
+    assert.equal($input.pickadate('picker').get('value'), formattedDate, "Expected pick a date to have date selected");
     //This ensures we don't get into weird cyclical conditions
     //If the user wants to set the value of the pick a date from an external source
     //then it is assumed they are setting it from the date object they passed into date=

--- a/tests/integration/components/pick-a-time-test.js
+++ b/tests/integration/components/pick-a-time-test.js
@@ -36,7 +36,7 @@ test('date is updated', function(assert) {
   let date = new Date();
   let initialDate = new Date(date);
   this.set('date', date);
-  this.render(hbs`{{pick-a-time date=date on-selected=(action (mut date))}}`);
+  this.render(hbs`{{pick-a-time date=(readonly date) on-selected=(action (mut date))}}`);
 
   assert.ok(this.get('date') === date, "Date set");
 
@@ -52,4 +52,22 @@ test('date is updated', function(assert) {
     assert.ok(this.get('date').getMonth() === initialDate.getMonth(), "Month didn't change");
     assert.ok(this.get('date').getDate() === initialDate.getDate(), "Day didn't change");
   });
+});
+
+test('can toggle disabled property', function(assert) {
+  this.set('disabled', true);
+  this.set('date', undefined);
+
+  this.render(hbs`
+    {{pick-a-time
+      date=(readonly date)
+      disabled=(readonly disabled)
+    }}
+  `);
+
+  let $input = this.$('input');
+  assert.equal($input.prop('disabled'), true);
+
+  this.set('disabled', false);
+  assert.equal($input.prop('disabled'), false);
 });

--- a/tests/integration/components/pick-a-time-test.js
+++ b/tests/integration/components/pick-a-time-test.js
@@ -7,24 +7,23 @@ moduleForComponent('pick-a-time', 'Integration | Component | pick a time', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
   this.render(hbs`{{pick-a-time}}`);
 
-  assert.equal(this.$('.ember-pick-a-time').length, 1);
-  assert.equal(this.$('.ember-pick-a-time input').length, 1);
+  assert.equal(this.$().length, 1);
 });
 
 test('placeholder is set', function(assert) {
   assert.expect(1);
   this.render(hbs`{{pick-a-time placeholder='pew'}}`);
 
-  assert.equal(this.$('.ember-pick-a-time input').attr('placeholder'), 'pew');
+  assert.equal(this.$('input').prop('placeholder'), 'pew');
 });
 
 test('clicking input opens picker', function(assert) {
   assert.expect(2);
   this.render(hbs`{{pick-a-time}}`);
-  let $input = this.$('.ember-pick-a-time input');
+  let $input = this.$('input');
 
   assert.notOk($input.hasClass('picker__input--active'));
 
@@ -37,14 +36,14 @@ test('date is updated', function(assert) {
   let date = new Date();
   let initialDate = new Date(date);
   this.set('date', date);
-  this.render(hbs`{{pick-a-time date=date}}`);
+  this.render(hbs`{{pick-a-time date=date on-selected=(action (mut date))}}`);
 
   assert.ok(this.get('date') === date, "Date set");
 
-  this.$('.ember-pick-a-time input').click();
+  this.$().click();
 
   Ember.run.next(() => {
-    this.$('.ember-pick-a-time .picker__list-item').click();
+    this.$('.picker__list-item').click();
 
     assert.ok(this.get('date') !== initialDate, "Date changed");
 


### PR DESCRIPTION
- Update to Data Down, Actions Up for ember 2.0+.
- Remove unnecessary templates, now people can apply their own classes to the input element as they wish.
- removed 2 way binding which is replaced by the `on-selected` action.
- pick-a-time now allows a `nulls-date` property for more flexibility when binding to the same date with both a time and date picker.
- Allow the input to be disabled by setting the `disabled` property to true.
- Properly update the date/time when they are updated outside of the control.
- add fix for bootstrap readonly inputs.
- updated tests.
