### PR TITLE
Fix set wrong month. Issue #14

### DIFF
--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -79,8 +79,8 @@ export default Component.extend({
 
     const newDate = new Date(date);
     newDate.setYear(dateItem.year);
-    newDate.setMonth(dateItem.month);
     newDate.setDate(dateItem.date);
+    newDate.setMonth(dateItem.month);
     if (this.attrs['on-selected']) {
       if (newDate && !isNaN(newDate.getTime())) { //Number.isNaN PhantomJs does not like this yet
         this.attrs['on-selected'](newDate);


### PR DESCRIPTION
When you try select date from next month, and next month do not contain selected date, it will set incorrect month value
#14
