### PR TITLE
[RFC] Read options from value

### DIFF
--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -28,6 +28,11 @@ export default Component.extend({
     options.onSet = () => {
       this.onSelected();
     };
+
+    for (var option in options.value) {
+      options[option] = options.value[option];
+    }
+
     this.$().pickadate(options);
     this.set('picker', this.$().pickadate('picker'));
   },


### PR DESCRIPTION
By default all the options are being store in a json called value inside options. The plugin pickadate is not loading at all this options.

This PR is to move this options at the value level to the root level.
