### PR TITLE
don't use attrs as it's not updated before computed props are fired

### DIFF
--- a/addon/components/pick-a-time.js
+++ b/addon/components/pick-a-time.js
@@ -73,7 +73,7 @@ export default Component.extend({
   }),
 
   optionsChanged: observer('options', function() {
-    let options = this.attrs.options;
+    let options = this.get('options');
 
     if (isEmpty(options)) {
       // TODO: unset options which were removed


### PR DESCRIPTION
Minor fix to ensure time picker options are updated correctly.
