### PR TITLE
Add event to onSelected

### DIFF
--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -25,8 +25,8 @@ export default Component.extend({
   didInsertElement() {
     const options = this.attrs.options || {};
     options.onClose = options.onClose || this.onClose;
-    options.onSet = () => {
-      this.onSelected();
+    options.onSet = (ev) => {
+      this.onSelected(ev);
     };
     this.$().pickadate(options);
     this.set('picker', this.$().pickadate('picker'));
@@ -66,13 +66,13 @@ export default Component.extend({
     Ember.$(document.activeElement).blur();
   },
 
-  onSelected(){
+  onSelected(ev){
     const date = this.get('date') || new Date();
     const picker = this.get('picker');
     const dateItem = picker.get('select');
     if (!dateItem) {
       if (this.attrs['on-selected']) {
-        this.attrs['on-selected'](null);
+        this.attrs['on-selected'](null, ev);
       }
       return;
     }
@@ -83,9 +83,9 @@ export default Component.extend({
     newDate.setDate(dateItem.date);
     if (this.attrs['on-selected']) {
       if (newDate && !isNaN(newDate.getTime())) { //Number.isNaN PhantomJs does not like this yet
-        this.attrs['on-selected'](newDate);
+        this.attrs['on-selected'](newDate, ev);
       } else {
-        this.attrs['on-selected'](null);
+        this.attrs['on-selected'](null, ev);
       }
     }
   },


### PR DESCRIPTION
Add event to be able to distinguish the origin of the event **onSet**. 

Why?
- Right now is impossible to distinguish between month change and date selection, as any onSet event returns a date.
