### PR TITLE
Update pick-a-date.js to fix month wrapping bug

### DIFF
--- a/addon/components/pick-a-date.js
+++ b/addon/components/pick-a-date.js
@@ -106,9 +106,10 @@ export default Component.extend({
     }
 
     const newDate = new Date(date);
+    newDate.setDate(1); // Prevent month wrapping bug (e.g. 31 April = 1 May)
     newDate.setYear(dateItem.year);
-    newDate.setDate(dateItem.date);
     newDate.setMonth(dateItem.month);
+    newDate.setDate(dateItem.date);
     if (this.attrs['on-selected']) {
       if (newDate && !isNaN(newDate.getTime())) { //Number.isNaN PhantomJs does not like this yet
         this.attrs['on-selected'](newDate, ev);


### PR DESCRIPTION
Related to issue #22, tested on the latest version of the code 1.2.0.

If we setDate before setMonth there is still a bug when we try to select dates with 31 when the current date is a month with less than 31 days. The following javascript illustrates the problem:

// Want to select 31 May 2016, the current date is 30 April 2016 (or any date in April, doesn't matter)
testDate = new Date(2016, 3, 30); console.log(testDate); // 30 April 2016
testDate.setYear(2016); console.log(testDate); // 30 April 2016, as expected
testDate.setDate(31); console.log(testDate); // 1 May 2016, not what we wanted
testDate.setMonth(4); console.log(testDate); // still 1 May 2016

I think at the moment setting the date to 1 before changing the month would be the safest change.
