### PR TITLE
Expose input `name` attribute to custom values

### DIFF
--- a/addon/components/picker.js
+++ b/addon/components/picker.js
@@ -5,7 +5,8 @@ const { Component, observer } = Ember;
 
 export default Component.extend({
   tagName: 'input',
-  attributeBindings: ['placeholder', 'disabled', 'type'],
+  attributeBindings: ['placeholder', 'disabled', 'type', 'name'],
+  name: null,
   disabled: null,
   type: 'text',
   date: null,


### PR DESCRIPTION
The name attribute cannot be customized from current component implementations. This could be useful when using properties such as `formatSubmit` in the pickadate options (http://amsul.ca/pickadate.js/date/#formats)
