### PR TITLE
Don't load pickadate in fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,11 @@ module.exports = {
     if (!options.theme) {
       options.theme = 'default';
     }
-
-    app.import(app.bowerDirectory + '/pickadate/lib/picker.js');
-    app.import(app.bowerDirectory + '/pickadate/lib/picker.date.js');
-    app.import(app.bowerDirectory + '/pickadate/lib/picker.time.js');
+    if(!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/pickadate/lib/picker.js');
+      app.import(app.bowerDirectory + '/pickadate/lib/picker.date.js');
+      app.import(app.bowerDirectory + '/pickadate/lib/picker.time.js');
+    }
     app.import(app.bowerDirectory + '/pickadate/lib/themes/' + options.theme + '.css');
     app.import(app.bowerDirectory + '/pickadate/lib/themes/' + options.theme + '.date.css');
     app.import(app.bowerDirectory + '/pickadate/lib/themes/' + options.theme + '.time.css');


### PR DESCRIPTION
In order for a fastboot application to boot, we cannot be loading the pickadate library.  It can be loaded after the client receives the javascript payload.

https://ember-fastboot.com/docs/addon-author-guide
