### PR TITLE
Incorrect config key "date" used by pick-a-time component

### DIFF
--- a/addon/components/pick-a-time.js
+++ b/addon/components/pick-a-time.js
@@ -25,7 +25,7 @@ export default Picker.extend({
   classNames: ['ember-pick-a-time'],
 
   didInsertElement() {
-    const defaults = this.getOptions().date;
+    const defaults = this.getOptions().time;
     const options = {
       ...defaults,
       ...this.attrs.options


### PR DESCRIPTION
Corrected the config key used by pick-a-time. Was "date", is now "time".  Just a small correction, that still managed to cause me a little puzzlement!